### PR TITLE
Use RequestHeader instead of Request[A]

### DIFF
--- a/module/src/main/scala/jp/t2v/lab/play20/auth/Auth.scala
+++ b/module/src/main/scala/jp/t2v/lab/play20/auth/Auth.scala
@@ -17,12 +17,12 @@ trait Auth {
   def optionalUserAction[A](p: BodyParser[A])(f: Option[User] => Request[A] => Result): Action[A] =
     Action(p)(req => f(restoreUser(req))(req))
 
-  def authorized[A](authority: Authority)(implicit request: Request[A]): Either[PlainResult, User] = for {
+  def authorized(authority: Authority)(implicit request: RequestHeader): Either[PlainResult, User] = for {
     user <- restoreUser(request).toRight(authenticationFailed(request)).right
     _ <- Either.cond(authorize(user, authority), (), authorizationFailed(request)).right
   } yield user
 
-  private def restoreUser[A](implicit request: Request[A]): Option[User] = for {
+  private def restoreUser(implicit request: RequestHeader): Option[User] = for {
     sessionId <- request.session.get("sessionId")
     userId <- resolver.sessionId2userId(sessionId)
     user <- resolveUser(userId)

--- a/module/src/main/scala/jp/t2v/lab/play20/auth/AuthConfig.scala
+++ b/module/src/main/scala/jp/t2v/lab/play20/auth/AuthConfig.scala
@@ -1,6 +1,6 @@
 package jp.t2v.lab.play20.auth
 
-import play.api.mvc.{Request, PlainResult}
+import play.api.mvc.{RequestHeader, PlainResult}
 
 trait AuthConfig {
 
@@ -16,16 +16,16 @@ trait AuthConfig {
 
   def resolveUser(id: Id): Option[User]
 
-  def loginSucceeded[A](request: Request[A]): PlainResult
+  def loginSucceeded(request: RequestHeader): PlainResult
 
-  def logoutSucceeded[A](request: Request[A]): PlainResult
+  def logoutSucceeded(request: RequestHeader): PlainResult
 
-  def authenticationFailed[A](request: Request[A]): PlainResult
+  def authenticationFailed(request: RequestHeader): PlainResult
 
-  def authorizationFailed[A](request: Request[A]): PlainResult
+  def authorizationFailed(request: RequestHeader): PlainResult
 
   def authorize(user: User, authority: Authority): Boolean
 
-  def resolver[A](implicit request: Request[A]): RelationResolver[Id] = new CacheRelationResolver[Id]
+  def resolver(implicit request: RequestHeader): RelationResolver[Id] = new CacheRelationResolver[Id]
 
 }

--- a/module/src/main/scala/jp/t2v/lab/play20/auth/CookieRelationResolver.scala
+++ b/module/src/main/scala/jp/t2v/lab/play20/auth/CookieRelationResolver.scala
@@ -3,7 +3,7 @@ package jp.t2v.lab.play20.auth
 import play.api.mvc._
 import scala.util.control.Exception._
 
-class CookieRelationResolver[Id : ToString : FromString, A](request: Request[A]) extends RelationResolver[Id] {
+class CookieRelationResolver[Id : ToString : FromString](request: RequestHeader) extends RelationResolver[Id] {
 
   private[auth] val UserIdKey = "AUTH_USER_ID"
 


### PR DESCRIPTION
This makes it possible to use authentication when
setting up WebSocket connection where there is
only RequestHeader available
