### PR TITLE
Update module/src/main/scala/jp/t2v/lab/play20/auth/CacheRelationResolve...

### DIFF
--- a/module/src/main/scala/jp/t2v/lab/play20/auth/CacheRelationResolver.scala
+++ b/module/src/main/scala/jp/t2v/lab/play20/auth/CacheRelationResolver.scala
@@ -26,10 +26,10 @@ class CacheRelationResolver[Id: ClassManifest] extends RelationResolver[Id] {
     unsetUserId(userId)
   }
   private[auth] def unsetSessionId(sessionId: String) {
-    Cache.set(sessionId + sessionIdSuffix, "", 1)
+    Cache.set(sessionId + sessionIdSuffix, None, 1)
   }
   private[auth] def unsetUserId(userId: Id) {
-    Cache.set(userId.toString + userIdSuffix, "", 1)
+    Cache.set(userId.toString + userIdSuffix, None, 1)
   }
 
   def store(sessionId: String, userId: Id, timeoutInSeconds: Int) = {


### PR DESCRIPTION
Version 0.3 of the module gives an Exception if using the memcached plugin:

play.core.ActionInvoker$$anonfun$receive$1$$anon$1: Execution exception [[NullPointerException: Can't serialize null]]
    at play.core.ActionInvoker$$anonfun$receive$1.apply(Invoker.scala:134) [play_2.9.1.jar:2.0.3]
    at play.core.ActionInvoker$$anonfun$receive$1.apply(Invoker.scala:115) [play_2.9.1.jar:2.0.3]
    at akka.actor.Actor$class.apply(Actor.scala:318) [akka-actor.jar:2.0.2]
    at play.core.ActionInvoker.apply(Invoker.scala:113) [play_2.9.1.jar:2.0.3]
    at akka.actor.ActorCell.invoke(ActorCell.scala:626) [akka-actor.jar:2.0.2]
    at akka.dispatch.Mailbox.processMailbox(Mailbox.scala:197) [akka-actor.jar:2.0.2]
Caused by: java.lang.NullPointerException: Can't serialize null
    at net.spy.memcached.transcoders.BaseSerializingTranscoder.serialize(BaseSerializingTranscoder.java:75) ~[spymemcached-2.6.jar:]
    at net.spy.memcached.transcoders.SerializingTranscoder.encode(SerializingTranscoder.java:135) ~[spymemcached-2.6.jar:]
    at net.spy.memcached.MemcachedClient.asyncStore(MemcachedClient.java:303) ~[spymemcached-2.6.jar:]
    at net.spy.memcached.MemcachedClient.set(MemcachedClient.java:658) ~[spymemcached-2.6.jar:]
    at com.github.mumoshu.play2.memcached.MemcachedPlugin$$anon$1.set(MemcachedPlugin.scala:99) ~[play2-memcached_2.9.1-0.2.1-SNAPSHOT.jar:0.2.1-SNAPSHOT]
    at play.api.cache.Cache$$anonfun$set$1.apply(Cache.scala:48) ~[play_2.9.1.jar:2.0.3]

I fixed this for me by storing empty strings "" instead of null in the Cache.
