### PR TITLE
Remove use of deprecated classManifest

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -10,6 +10,7 @@ import play.api.mvc.Results._
 import jp.t2v.lab.play20.auth._
 import play.api.Play._
 import play.api.cache.Cache
+import scala.reflect.classTag
 
 object Application extends Controller with LoginLogout with AuthConfigImpl {
 
@@ -68,7 +69,7 @@ trait AuthConfigImpl extends AuthConfig {
 
   type Authority = Permission
 
-  val idManifest = classManifest[Id]
+  val idManifest = classTag[Id]
 
   val sessionTimeoutInSeconds = 3600
 


### PR DESCRIPTION
The use of the deprecated classManifest was causing some problems compiling with play-2.1-RC1. 

Updated the sample app with classTag to avoid the problems.
