### PR TITLE
Typo in http unauthorized instead of redirect when request by ajax

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,10 +396,10 @@ object Application extends Controller with AuthenticationElement with AuthConfig
 ```
 
 
-### return 401 when a request is sent by Ajax
+### Return 401 when a request is sent by Ajax
 
 Normally, you want to return a login page redirection at a authentication failed.
-Although, when the request is sent by Ajax you want to return 301.
+Although, when the request is sent by Ajax you want to instead return 401, Unauthorized.
 
 You can do it as follows.
 


### PR DESCRIPTION
Just a little correction in the Readme.md. 

In the Redirect a 401 for Ajax calls, I think there was a typo in the text stating a 301 instead of a 401.
