### PR TITLE
Alter withLoggedIn to return a function yielding a FakeRequest...

### DIFF
--- a/test/src/main/scala/jp/t2v/lab/play2/auth/test/Helpers.scala
+++ b/test/src/main/scala/jp/t2v/lab/play2/auth/test/Helpers.scala
@@ -9,7 +9,7 @@ trait Helpers {
 
   implicit class AuthFakeRequest[A](fakeRequest: FakeRequest[A]) {
 
-    def withLoggedIn(implicit config: AuthConfig): config.Id => Request[A] = { id =>
+    def withLoggedIn(implicit config: AuthConfig): config.Id => FakeRequest[A] = { id =>
       val token = config.idContainer.startNewSession(id, config.sessionTimeoutInSeconds)
       val value = Crypto.sign(token) + token
       import config._


### PR DESCRIPTION
...rather than just a Request. This allows you to continue to use extension methods such as withHeaders and withCookies.
