### PR TITLE
fix travis setting. use default travis sbt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,3 @@
 language: scala
-script: ./travis.sh
+scala:
+  - 2.10.3

--- a/travis.sh
+++ b/travis.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-wget https://raw.github.com/paulp/sbt-extras/master/sbt &&
-chmod u+x ./sbt &&
-./sbt -sbt-version 0.13.0 test


### PR DESCRIPTION
test failure if use `paulp/sbt-extras`'s default memory settings.
https://travis-ci.org/t2v/play2-auth/builds/17232026#L42

```
Error: Could not find or load main class # Tweaking for VM equipped with 3GB of RAM
```

we can use default travis sbt.
