### PR TITLE
Update for Play 2.3 (as of M1)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -118,25 +118,25 @@ For example: `Build.scala`
       /**
        * ログインが成功した際に遷移する先を指定します。
        */
-      def loginSucceeded(request: RequestHeader)(implicit ctx: ExecutionContext): Future[SimpleResult] =
+      def loginSucceeded(request: RequestHeader)(implicit ctx: ExecutionContext): Future[Result] =
         Future.successful(Redirect(routes.Message.main))
 
       /**
        * ログアウトが成功した際に遷移する先を指定します。
        */
-      def logoutSucceeded(request: RequestHeader)(implicit ctx: ExecutionContext): Future[SimpleResult] =
+      def logoutSucceeded(request: RequestHeader)(implicit ctx: ExecutionContext): Future[Result] =
         Future.successful(Redirect(routes.Application.login))
 
       /**
        * 認証が失敗した場合に遷移する先を指定します。
        */
-      def authenticationFailed(request: RequestHeader)(implicit ctx: ExecutionContext): Future[SimpleResult] =
+      def authenticationFailed(request: RequestHeader)(implicit ctx: ExecutionContext): Future[Result] =
         Future.successful(Redirect(routes.Application.login))
 
       /**
        * 認可(権限チェック)が失敗した場合に遷移する先を指定します。
        */
-      def authorizationFailed(request: RequestHeader)(implicit ctx: ExecutionContext): Future[SimpleResult] = 
+      def authorizationFailed(request: RequestHeader)(implicit ctx: ExecutionContext): Future[Result] = 
         Future.successful(Forbidden("no permission"))
 
       /**
@@ -183,7 +183,7 @@ For example: `Build.scala`
        * ログアウト処理では任意の処理を行った後、
        * gotoLogoutSucceeded メソッドを呼び出した結果を返して下さい。
        *
-       * gotoLogoutSucceeded メソッドは Future[SimpleResult] を返します。
+       * gotoLogoutSucceeded メソッドは Future[Result] を返します。
        * 以下のようにflashingなどを追加することもできます。
        *
        *   gotoLogoutSucceeded.map(_.flashing(
@@ -199,7 +199,7 @@ For example: `Build.scala`
        * ログイン処理では認証が成功した場合、
        * gotoLoginSucceeded メソッドを呼び出した結果を返して下さい。
        *
-       * gotoLoginSucceeded メソッドも gotoLogoutSucceeded と同じく Future[SimpleResult] を返します。
+       * gotoLoginSucceeded メソッドも gotoLogoutSucceeded と同じく Future[Result] を返します。
        * 任意の処理を追加することも可能です。
        */
       def authenticate = Action.async { implicit request =>
@@ -350,10 +350,10 @@ trait AuthConfigImpl extends AuthConfig {
 
   // 他の設定省略
 
-  def authenticationFailed(request: RequestHeader)(implicit ctx: ExecutionContext): Future[SimpleResult] =
+  def authenticationFailed(request: RequestHeader)(implicit ctx: ExecutionContext): Future[Result] =
     Future.successful(Redirect(routes.Application.login).withSession("access_uri" -> request.uri))
 
-  def loginSucceeded(request: RequestHeader)(implicit ctx: ExecutionContext): Future[SimpleResult] = {
+  def loginSucceeded(request: RequestHeader)(implicit ctx: ExecutionContext): Future[Result] = {
     val uri = request.session.get("access_uri").getOrElse(routes.Message.main.url)
     Future.successful(Redirect(uri).withSession(request.session - "access_uri"))
   }
@@ -432,7 +432,7 @@ def authenticationFailed(request: RequestHeader)(implicit ctx: ExecutionContext)
 ```scala
 import jp.t2v.lab.play2.stackc.{RequestWithAttributes, StackableController}
 import scala.concurrent.Future
-import play.api.mvc.{SimpleResult, Request, Controller}
+import play.api.mvc.{Result, Request, Controller}
 import play.api.data._
 import play.api.data.Forms._
 
@@ -448,7 +448,7 @@ trait TokenValidateElement extends StackableController {
     tokenInSession <- request.session.get("token")
   } yield tokenInForm == tokenInSession).getOrElse(false)
 
-  override def proceed[A](request: RequestWithAttributes[A])(f: RequestWithAttributes[A] => Future[SimpleResult]): Future[SimpleResult] = {
+  override def proceed[A](request: RequestWithAttributes[A])(f: RequestWithAttributes[A] => Future[Result]): Future[Result] = {
     if (validateToken(request)) super.proceed(request)(f)
     else Future.successful(BadRequest)
   }
@@ -482,7 +482,7 @@ object Application extends Controller with TokenValidateElement with AuthElement
 効率的なアプリケーションを作成するため、昨今ではReactiveなアプローチが人気を博しています。
 Playはこういった非同期なアプローチが得意であり、[ReactiveMongo](http://reactivemongo.org/) や [ScalikeJDBC-Async](https://github.com/seratch/scalikejdbc-async) などといった非同期なライブラリを上手に使用する事ができます。
 
-`StackAction` の代わりに `AsyncStack` を使用することで、 Future[SimpleResult] を返すアクションを簡単につくることができます。
+`StackAction` の代わりに `AsyncStack` を使用することで、 Future[Result] を返すアクションを簡単につくることができます。
 
 
 ```scala

--- a/README.md
+++ b/README.md
@@ -120,25 +120,25 @@ Usage
       /**
        * Where to redirect the user after a successful login.
        */
-      def loginSucceeded(request: RequestHeader)(implicit ctx: ExecutionContext): Future[SimpleResult] =
+      def loginSucceeded(request: RequestHeader)(implicit ctx: ExecutionContext): Future[Result] =
         Future.successful(Redirect(routes.Message.main))
 
       /**
        * Where to redirect the user after logging out
        */
-      def logoutSucceeded(request: RequestHeader)(implicit ctx: ExecutionContext): Future[SimpleResult] =
+      def logoutSucceeded(request: RequestHeader)(implicit ctx: ExecutionContext): Future[Result] =
         Future.successful(Redirect(routes.Application.login))
 
       /**
        * If the user is not logged in and tries to access a protected resource then redirct them as follows:
        */
-      def authenticationFailed(request: RequestHeader)(implicit ctx: ExecutionContext): Future[SimpleResult] =
+      def authenticationFailed(request: RequestHeader)(implicit ctx: ExecutionContext): Future[Result] =
         Future.successful(Redirect(routes.Application.login))
 
       /**
        * If authorization failed (usually incorrect password) redirect the user as follows:
        */
-      def authorizationFailed(request: RequestHeader)(implicit ctx: ExecutionContext): Future[SimpleResult] = 
+      def authorizationFailed(request: RequestHeader)(implicit ctx: ExecutionContext): Future[Result] = 
         Future.successful(Forbidden("no permission"))
 
       /**
@@ -183,7 +183,7 @@ Usage
       /**
        * Return the `gotoLogoutSucceeded` method's result in the logout action.
        *
-       * Since the `gotoLogoutSucceeded` returns `Future[SimpleResult]`,
+       * Since the `gotoLogoutSucceeded` returns `Future[Result]`,
        * you can add a procedure like the following.
        *
        *   gotoLogoutSucceeded.map(_.flashing(
@@ -198,7 +198,7 @@ Usage
       /**
        * Return the `gotoLoginSucceeded` method's result in the login action.
        *
-       * Since the `gotoLoginSucceeded` returns `Future[SimpleResult]`,
+       * Since the `gotoLoginSucceeded` returns `Future[Result]`,
        * you can add a procedure like the `gotoLogoutSucceeded`.
        */
       def authenticate = Action.async { implicit request =>
@@ -349,10 +349,10 @@ trait AuthConfigImpl extends AuthConfig {
 
   // Other settings are omitted.
 
-  def authenticationFailed(request: RequestHeader)(implicit ctx: ExecutionContext): Future[SimpleResult] =
+  def authenticationFailed(request: RequestHeader)(implicit ctx: ExecutionContext): Future[Result] =
     Future.successful(Redirect(routes.Application.login).withSession("access_uri" -> request.uri))
 
-  def loginSucceeded(request: RequestHeader)(implicit ctx: ExecutionContext): Future[SimpleResult] = {
+  def loginSucceeded(request: RequestHeader)(implicit ctx: ExecutionContext): Future[Result] = {
     val uri = request.session.get("access_uri").getOrElse(routes.Message.main.url.toString)
     Future.successful(Redirect(uri).withSession(request.session - "access_uri"))
   }
@@ -425,7 +425,7 @@ Since it is impractical to perform the validation in all actions, you would defi
 ```scala
 import jp.t2v.lab.play2.stackc.{RequestWithAttributes, StackableController}
 import scala.concurrent.Future
-import play.api.mvc.{SimpleResult, Request, Controller}
+import play.api.mvc.{Result, Request, Controller}
 import play.api.data._
 import play.api.data.Forms._
 
@@ -439,7 +439,7 @@ trait TokenValidateElement extends StackableController {
     tokenInSession <- request.session.get("token")
   } yield tokenInForm == tokenInSession).getOrElse(false)
 
-  override def proceed[A](request: RequestWithAttributes[A])(f: RequestWithAttributes[A] => Future[SimpleResult]): Future[SimpleResult] = {
+  override def proceed[A](request: RequestWithAttributes[A])(f: RequestWithAttributes[A] => Future[Result]): Future[Result] = {
     if (validateToken(request)) super.proceed(request)(f)
     else Future.successful(BadRequest)
   }
@@ -469,9 +469,9 @@ object Application extends Controller with TokenValidateElement with AuthElement
 
 There are asynchronous libraries ( for example: [ReactiveMongo](http://reactivemongo.org/), [ScalikeJDBC-Async](https://github.com/seratch/scalikejdbc-async), and so on ).
 
-You should use `Future[SimpleResult]` instead of `AsyncResult` from Play2.2. 
+You should use `Future[Result]` instead of `AsyncResult` from Play2.2. 
 
-You can use `AsyncStack` instead of `StackAction` for Future[SimpleResult]
+You can use `AsyncStack` instead of `StackAction` for Future[Result]
 
 ```scala
 trait HogeController extends AuthElement with AuthConfigImpl {

--- a/module/src/main/scala/jp/t2v/lab/play2/auth/Auth.scala
+++ b/module/src/main/scala/jp/t2v/lab/play2/auth/Auth.scala
@@ -5,39 +5,39 @@ import play.api.libs.iteratee.{Input, Done}
 import scala.concurrent.{Future, Await}
 import scala.concurrent.duration._
 
-@deprecated
+@deprecated(message = "AsyncAuth should be preferred", since = "0.11.0")
 trait Auth {
   self: AuthConfig =>
 
   private implicit val ctx = play.api.libs.concurrent.Execution.defaultContext
 
   object authorizedAction {
-    def async(authority: Authority)(f: User => Request[AnyContent] => Future[SimpleResult]): Action[(AnyContent, User)] =
+    def async(authority: Authority)(f: User => Request[AnyContent] => Future[Result]): Action[(AnyContent, User)] =
       async(BodyParsers.parse.anyContent, authority)(f)
 
-    def async[A](p: BodyParser[A], authority: Authority)(f: User => Request[A] => Future[SimpleResult]): Action[(A, User)] = {
+    def async[A](p: BodyParser[A], authority: Authority)(f: User => Request[A] => Future[Result]): Action[(A, User)] = {
       val parser = BodyParser {
         req => authorized(authority)(req) match {
-          case Right(user)  => p.map((_, user))(req)
+          case Right(user)  => p.map((_, user)).apply(req)
           case Left(result) => Done(Left(result), Input.Empty)
         }
       }
       Action.async(parser) { req => f(req.body._2)(req.map(_._1)) }
     }
 
-    def apply(authority: Authority)(f: User => (Request[AnyContent] => SimpleResult)): Action[(AnyContent, User)] =
+    def apply(authority: Authority)(f: User => (Request[AnyContent] => Result)): Action[(AnyContent, User)] =
       async(authority)(f.andThen(_.andThen(t=>Future.successful(t))))
-    def apply[A](p: BodyParser[A], authority: Authority)(f: User => Request[A] => SimpleResult): Action[(A, User)] =
+    def apply[A](p: BodyParser[A], authority: Authority)(f: User => Request[A] => Result): Action[(A, User)] =
       async(p,authority)(f.andThen(_.andThen(t=>Future.successful(t))))
   }
 
-  def optionalUserAction(f: Option[User] => Request[AnyContent] => Future[SimpleResult]): Action[AnyContent] =
+  def optionalUserAction(f: Option[User] => Request[AnyContent] => Future[Result]): Action[AnyContent] =
     optionalUserAction(BodyParsers.parse.anyContent)(f)
 
-  def optionalUserAction[A](p: BodyParser[A])(f: Option[User] => Request[A] => Future[SimpleResult]): Action[A] =
+  def optionalUserAction[A](p: BodyParser[A])(f: Option[User] => Request[A] => Future[Result]): Action[A] =
     Action.async(p)(req => f(restoreUser(req))(req))
 
-  def authorized(authority: Authority)(implicit request: RequestHeader): Either[SimpleResult, User] = for {
+  def authorized(authority: Authority)(implicit request: RequestHeader): Either[Result, User] = for {
     user <- restoreUser(request).toRight(Await.result(authenticationFailed(request), 10.seconds)).right
     _    <- Either.cond(Await.result(authorize(user, authority), 10.seconds), (), Await.result(authorizationFailed(request), 10.seconds)).right
   } yield user

--- a/module/src/main/scala/jp/t2v/lab/play2/auth/AuthConfig.scala
+++ b/module/src/main/scala/jp/t2v/lab/play2/auth/AuthConfig.scala
@@ -18,13 +18,13 @@ trait AuthConfig {
 
   def resolveUser(id: Id)(implicit context: ExecutionContext): Future[Option[User]]
 
-  def loginSucceeded(request: RequestHeader)(implicit context: ExecutionContext): Future[SimpleResult]
+  def loginSucceeded(request: RequestHeader)(implicit context: ExecutionContext): Future[Result]
 
-  def logoutSucceeded(request: RequestHeader)(implicit context: ExecutionContext): Future[SimpleResult]
+  def logoutSucceeded(request: RequestHeader)(implicit context: ExecutionContext): Future[Result]
 
-  def authenticationFailed(request: RequestHeader)(implicit context: ExecutionContext): Future[SimpleResult]
+  def authenticationFailed(request: RequestHeader)(implicit context: ExecutionContext): Future[Result]
 
-  def authorizationFailed(request: RequestHeader)(implicit context: ExecutionContext): Future[SimpleResult]
+  def authorizationFailed(request: RequestHeader)(implicit context: ExecutionContext): Future[Result]
 
   def authorize(user: User, authority: Authority)(implicit context: ExecutionContext): Future[Boolean]
 

--- a/module/src/main/scala/jp/t2v/lab/play2/auth/AuthElement.scala
+++ b/module/src/main/scala/jp/t2v/lab/play2/auth/AuthElement.scala
@@ -1,6 +1,6 @@
 package jp.t2v.lab.play2.auth
 
-import play.api.mvc.{SimpleResult, Controller}
+import play.api.mvc.{Result, Controller}
 import jp.t2v.lab.play2.stackc.{RequestWithAttributes, RequestAttributeKey, StackableController}
 import scala.concurrent.Future
 
@@ -10,7 +10,7 @@ trait AuthElement extends StackableController with AsyncAuth {
   private[auth] case object AuthKey extends RequestAttributeKey[User]
   case object AuthorityKey extends RequestAttributeKey[Authority]
 
-  override def proceed[A](req: RequestWithAttributes[A])(f: RequestWithAttributes[A] => Future[SimpleResult]): Future[SimpleResult] = {
+  override def proceed[A](req: RequestWithAttributes[A])(f: RequestWithAttributes[A] => Future[Result]): Future[Result] = {
     implicit val (r, ctx) = (req, StackActionExecutionContext(req))
     req.get(AuthorityKey) map { authority =>
       authorized(authority) flatMap {
@@ -31,7 +31,7 @@ trait OptionalAuthElement extends StackableController with AsyncAuth {
 
   private[auth] case object AuthKey extends RequestAttributeKey[User]
 
-  override def proceed[A](req: RequestWithAttributes[A])(f: RequestWithAttributes[A] => Future[SimpleResult]): Future[SimpleResult] = {
+  override def proceed[A](req: RequestWithAttributes[A])(f: RequestWithAttributes[A] => Future[Result]): Future[Result] = {
     implicit val (r, ctx) = (req, StackActionExecutionContext(req))
     val maybeUserFuture = restoreUser.recover { case _ => Option.empty }
     maybeUserFuture.flatMap(maybeUser => super.proceed(maybeUser.map(u => req.set(AuthKey, u)).getOrElse(req))(f))
@@ -45,7 +45,7 @@ trait AuthenticationElement extends StackableController with AsyncAuth {
 
   private[auth] case object AuthKey extends RequestAttributeKey[User]
 
-  override def proceed[A](req: RequestWithAttributes[A])(f: RequestWithAttributes[A] => Future[SimpleResult]): Future[SimpleResult] = {
+  override def proceed[A](req: RequestWithAttributes[A])(f: RequestWithAttributes[A] => Future[Result]): Future[Result] = {
     implicit val (r, ctx) = (req, StackActionExecutionContext(req))
     restoreUser recover {
       case _ => Option.empty

--- a/module/src/main/scala/jp/t2v/lab/play2/auth/LoginLogout.scala
+++ b/module/src/main/scala/jp/t2v/lab/play2/auth/LoginLogout.scala
@@ -8,21 +8,21 @@ import scala.concurrent.{Future, ExecutionContext}
 trait LoginLogout {
   self: Controller with AuthConfig =>
 
-  def gotoLoginSucceeded(userId: Id)(implicit request: RequestHeader, ctx: ExecutionContext): Future[SimpleResult] = {
+  def gotoLoginSucceeded(userId: Id)(implicit request: RequestHeader, ctx: ExecutionContext): Future[Result] = {
     gotoLoginSucceeded(userId, loginSucceeded(request))
   }
 
-  def gotoLoginSucceeded(userId: Id, result: => Future[SimpleResult])(implicit ctx: ExecutionContext): Future[SimpleResult] = {
+  def gotoLoginSucceeded(userId: Id, result: => Future[Result])(implicit ctx: ExecutionContext): Future[Result] = {
     val token = idContainer.startNewSession(userId, sessionTimeoutInSeconds)
     val value = Crypto.sign(token) + token
     result.map(_.withCookies(Cookie(cookieName, value, None, cookiePathOption, cookieDomainOption, cookieSecureOption, cookieHttpOnlyOption)))
   }
 
-  def gotoLogoutSucceeded(implicit request: RequestHeader, ctx: ExecutionContext): Future[SimpleResult] = {
+  def gotoLogoutSucceeded(implicit request: RequestHeader, ctx: ExecutionContext): Future[Result] = {
     gotoLogoutSucceeded(logoutSucceeded(request))
   }
 
-  def gotoLogoutSucceeded(result: => Future[SimpleResult])(implicit request: RequestHeader, ctx: ExecutionContext): Future[SimpleResult] = {
+  def gotoLogoutSucceeded(result: => Future[Result])(implicit request: RequestHeader, ctx: ExecutionContext): Future[Result] = {
     request.cookies.get(cookieName) flatMap CookieUtil.verifyHmac foreach idContainer.remove
     result.map(_.discardingCookies(DiscardingCookie(cookieName)))
   }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -6,11 +6,11 @@ object ApplicationBuild extends Build {
 
   val appName    = "play2-auth"
 
-  val playVersion = "2.2.0"
+  val playVersion = "2.3-M1"
 
   lazy val baseSettings = Seq(
-    version            := "0.11.0",
-    scalaVersion       := "2.10.3",
+    version            := "0.12.0",
+    scalaVersion       := "2.10.4",
     scalaBinaryVersion := "2.10",
     organization       := "jp.t2v",
     resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.0
+sbt.version=0.13.5-M2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,5 +7,5 @@ resolvers ++= Seq(
 )
 
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.2.1")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.3-M1")
 

--- a/sample/app/controllers/Application.scala
+++ b/sample/app/controllers/Application.scala
@@ -129,7 +129,7 @@ trait Pjax extends StackableController {
 
   case object TemplateKey extends RequestAttributeKey[Template]
 
-  abstract override def proceed[A](req: RequestWithAttributes[A])(f: RequestWithAttributes[A] => Future[SimpleResult]): Future[SimpleResult] = {
+  abstract override def proceed[A](req: RequestWithAttributes[A])(f: RequestWithAttributes[A] => Future[Result]): Future[Result] = {
     val template: Template = if (req.headers.keys("X-Pjax")) html.pjaxTemplate.apply else html.fullTemplate.apply(loggedIn(req))
     super.proceed(req.set(TemplateKey, template))(f)
   }

--- a/sample/app/controllers/stack/TokenValidateElement.scala
+++ b/sample/app/controllers/stack/TokenValidateElement.scala
@@ -2,7 +2,7 @@ package controller.stack
 
 import jp.t2v.lab.play2.stackc.{RequestWithAttributes, StackableController}
 import scala.concurrent.Future
-import play.api.mvc.{SimpleResult, Request, Controller}
+import play.api.mvc.{Result, Request, Controller}
 import play.api.data._
 import play.api.data.Forms._
 
@@ -18,7 +18,7 @@ trait TokenValidateElement extends StackableController {
     tokenInSession <- request.session.get("token")
   } yield tokenInForm == tokenInSession).getOrElse(false)
 
-  override def proceed[A](request: RequestWithAttributes[A])(f: RequestWithAttributes[A] => Future[SimpleResult]): Future[SimpleResult] = {
+  override def proceed[A](request: RequestWithAttributes[A])(f: RequestWithAttributes[A] => Future[Result]): Future[Result] = {
     if (validateToken(request)) super.proceed(request)(f)
     else Future.successful(BadRequest)
   }

--- a/sample/conf/db/migration/default/V1__create_tables.sql
+++ b/sample/conf/db/migration/default/V1__create_tables.sql
@@ -1,7 +1,7 @@
 CREATE TABLE account (
     id         integer NOT NULL PRIMARY KEY,
-    email      text NOT NULL UNIQUE,
-    password   text NOT NULL,
-    name       text NOT NULL,
-    permission text NOT NULL
+    email      varchar NOT NULL UNIQUE,
+    password   varchar NOT NULL,
+    name       varchar NOT NULL,
+    permission varchar NOT NULL
 );

--- a/sample/test/IntegrationSpec.scala
+++ b/sample/test/IntegrationSpec.scala
@@ -10,7 +10,7 @@ class IntegrationSpec extends Specification {
   
   "Application" should {
     
-    "work from within a browser" in new WithBrowser(webDriver = HTMLUNIT, app = FakeApplication(additionalConfiguration = inMemoryDatabase(name = "default", options = Map("DB_CLOSE_DELAY" -> "-1")))) {
+    "work from within a browser" in new WithBrowser(webDriver = WebDriverFactory(HTMLUNIT), app = FakeApplication(additionalConfiguration = inMemoryDatabase(name = "default", options = Map("DB_CLOSE_DELAY" -> "-1")))) {
 
       val baseURL = s"http://localhost:${port}"
       // login failed
@@ -37,7 +37,7 @@ class IntegrationSpec extends Specification {
 
     }
 
-    "authorize" in new WithBrowser(webDriver = HTMLUNIT, app = FakeApplication(additionalConfiguration = inMemoryDatabase(name = "default", options = Map("DB_CLOSE_DELAY" -> "-1")))) {
+    "authorize" in new WithBrowser(webDriver = WebDriverFactory(HTMLUNIT), app = FakeApplication(additionalConfiguration = inMemoryDatabase(name = "default", options = Map("DB_CLOSE_DELAY" -> "-1")))) {
 
       val baseURL = s"http://localhost:${port}"
 


### PR DESCRIPTION
- Fix compilation errors related to BodyParser
- Change SimpleResult to Result
- add `message` and `since` args to deprecation warning on Auth trait
- Tweak webdriver constructor in tests
- Tweak DB tables to fix H2 index-on-text column error

Note: Play and SBT versions are 2.3-M1 and 0.13.5-M2 respectively.
