### PR TITLE
日本語用サンプルコードのタイポ修正 (modify typo)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -244,7 +244,7 @@ For example: `Build.scala`
       }
 
       // このActionだけ、Administrator でなければ実行できなくなります。
-      def write = aStackAction(AuthorityKey -> Administrator) { implicit request =>
+      def write = StackAction(AuthorityKey -> Administrator) { implicit request =>
         val user = loggedIn
         val title = "write message"
         Ok(html.message.write(title))


### PR DESCRIPTION
英語版に無い訳出途中にくっついたと思われる文字を削除しました。
