### PR TITLE
Update usage of CookieIdContainer for 0.13

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -520,7 +520,7 @@ trait AuthConfigImpl extends AuthConfig {
 
   // 他の設定省略
 
-  override lazy val idContainer: IdContainer[Id] = new CookieIdContainer[Id]
+  override lazy val idContainer: AsyncIdContainer[Id] = AsyncIdContainer(new CookieIdContainer[Id])
 
 }
 ```

--- a/README.md
+++ b/README.md
@@ -510,7 +510,7 @@ trait AuthConfigImpl extends AuthConfig {
 
   // Other settings omitted.
 
-  override lazy val idContainer: IdContainer[Id] = new CookieIdContainer[Id]
+  override lazy val idContainer: AsyncIdContainer[Id] = AsyncIdContainer(new CookieIdContainer[Id])
 
 }
 ```


### PR DESCRIPTION
Fix small documentation issue found when upgrading to 0.13.
