### PR TITLE
Divided LoginLogout trait to Login and Logout

### DIFF
--- a/module/src/main/scala/jp/t2v/lab/play2/auth/LoginLogout.scala
+++ b/module/src/main/scala/jp/t2v/lab/play2/auth/LoginLogout.scala
@@ -5,7 +5,7 @@ import play.api.mvc.Cookie
 import play.api.libs.Crypto
 import scala.concurrent.{Future, ExecutionContext}
 
-trait LoginLogout {
+trait Login {
   self: Controller with AuthConfig =>
 
   def gotoLoginSucceeded(userId: Id)(implicit request: RequestHeader, ctx: ExecutionContext): Future[Result] = {
@@ -16,6 +16,10 @@ trait LoginLogout {
     token <- idContainer.startNewSession(userId, sessionTimeoutInSeconds)
     r     <- result
   } yield tokenAccessor.put(token)(r)
+}
+
+trait Logout {
+  self: Controller with AuthConfig =>
 
   def gotoLogoutSucceeded(implicit request: RequestHeader, ctx: ExecutionContext): Future[Result] = {
     gotoLogoutSucceeded(logoutSucceeded(request))
@@ -25,4 +29,8 @@ trait LoginLogout {
     tokenAccessor.extract(request) foreach idContainer.remove
     result.map(tokenAccessor.delete)
   }
+}
+
+trait LoginLogout extends Login with Logout {
+  self: Controller with AuthConfig =>
 }


### PR DESCRIPTION
I'm working on social login with play2-auth and have a usecase of this.

The interface is like this now.

```scala
object GitHubAuthController extends OAuth2Controller[User]
    with AuthConfigImpl
    with LoginLogout
    with OptionalAuthElement {
  lazy val authenticator = githubAuthenticator
}

object FacebookAuthController extends OAuth2Controller[User]
    with AuthConfigImpl
    with LoginLogout 
    with OptionalAuthElement {
  lazy val authenticator = facebookAuthenticator
}

object TwitterAuthController extends OAuth10aController[User]
    with AuthConfigImpl
    with LoginLogout
    with OptionalAuthElement {
  lazy val authenticator = twitterAuthenticator
}
```

Each controller has `login` method, but doesn't have `logout`. On the other hand, as `login` methods are in `XXXAuthController`, My `LoginController` has only `logout` method.
If `Login` and `Logout` traits exist, I want to use them.

