### PR TITLE
Remove '!' from token character table

### DIFF
--- a/module/src/main/scala/jp/t2v/lab/play2/auth/CacheIdContainer.scala
+++ b/module/src/main/scala/jp/t2v/lab/play2/auth/CacheIdContainer.scala
@@ -22,7 +22,7 @@ class CacheIdContainer[Id: ClassTag] extends IdContainer[Id] {
 
   @tailrec
   private[auth] final def generate: AuthenticityToken = {
-    val table = "abcdefghijklmnopqrstuvwxyz1234567890_.!~*'()"
+    val table = "abcdefghijklmnopqrstuvwxyz1234567890_.~*'()"
     val token = Iterator.continually(random.nextInt(table.size)).map(table).take(64).mkString
     if (get(token).isDefined) generate else token
   }


### PR DESCRIPTION
Netty require for cookie value symbols between 0x23 and 0x56 exclude: 0x2C, 0x3B and 0x5C

You can take actual limitation at https://github.com/netty/netty/blob/master/codec-http/src/main/java/io/netty/handler/codec/http/cookie/CookieUtil.java