### PR TITLE
Prevent assertion error when using the `withLoggedIn` test helper.

### DIFF
--- a/module/src/main/scala/jp/t2v/lab/play2/auth/CookieTokenAccessor.scala
+++ b/module/src/main/scala/jp/t2v/lab/play2/auth/CookieTokenAccessor.scala
@@ -3,12 +3,12 @@ package jp.t2v.lab.play2.auth
 import play.api.mvc.{DiscardingCookie, Cookie, Result, RequestHeader}
 
 class CookieTokenAccessor(
-    protected val cookieName: String = "PLAY2AUTH_SESS_ID",
-    protected val cookieSecureOption: Boolean = false,
-    protected val cookieHttpOnlyOption: Boolean = true,
-    protected val cookieDomainOption: Option[String] = None,
-    protected val cookiePathOption: String = "/",
-    protected val cookieMaxAge: Option[Int] = None
+    val cookieName: String = "PLAY2AUTH_SESS_ID",
+    val cookieSecureOption: Boolean = false,
+    val cookieHttpOnlyOption: Boolean = true,
+    val cookieDomainOption: Option[String] = None,
+    val cookiePathOption: String = "/",
+    val cookieMaxAge: Option[Int] = None
 ) extends TokenAccessor {
 
   def put(token: AuthenticityToken)(result: Result)(implicit request: RequestHeader): Result = {

--- a/test/src/main/scala/jp/t2v/lab/play2/auth/test/Helpers.scala
+++ b/test/src/main/scala/jp/t2v/lab/play2/auth/test/Helpers.scala
@@ -2,7 +2,7 @@ package jp.t2v.lab.play2.auth.test
 
 import play.api.test._
 import play.api.mvc.Cookie
-import jp.t2v.lab.play2.auth.AuthConfig
+import jp.t2v.lab.play2.auth.{AuthConfig, CookieTokenAccessor}
 import play.api.libs.Crypto
 import scala.concurrent.Await
 import scala.concurrent.duration._
@@ -10,12 +10,11 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 trait Helpers {
 
-  implicit class AuthFakeRequest[A](fakeRequest: FakeRequest[A]) {
+  implicit class AuthFakeRequest[A](fakeRequest: FakeRequest[A]) extends CookieTokenAccessor {
 
     def withLoggedIn(implicit config: AuthConfig): config.Id => FakeRequest[A] = { id =>
       val token = Await.result(config.idContainer.startNewSession(id, config.sessionTimeoutInSeconds)(fakeRequest, global), 10.seconds)
       val value = Crypto.sign(token) + token
-      import config._
       fakeRequest.withCookies(Cookie(cookieName, value, None, cookiePathOption, cookieDomainOption, cookieSecureOption, cookieHttpOnlyOption))
     }
 

--- a/test/src/main/scala/jp/t2v/lab/play2/auth/test/Helpers.scala
+++ b/test/src/main/scala/jp/t2v/lab/play2/auth/test/Helpers.scala
@@ -10,12 +10,18 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 trait Helpers {
 
-  implicit class AuthFakeRequest[A](fakeRequest: FakeRequest[A]) extends CookieTokenAccessor {
+  implicit class AuthFakeRequest[A](fakeRequest: FakeRequest[A]) {
 
     def withLoggedIn(implicit config: AuthConfig): config.Id => FakeRequest[A] = { id =>
-      val token = Await.result(config.idContainer.startNewSession(id, config.sessionTimeoutInSeconds)(fakeRequest, global), 10.seconds)
-      val value = Crypto.sign(token) + token
-      fakeRequest.withCookies(Cookie(cookieName, value, None, cookiePathOption, cookieDomainOption, cookieSecureOption, cookieHttpOnlyOption))
+      config.tokenAccessor match {
+        case cta: CookieTokenAccessor =>
+          val token = Await.result(config.idContainer.startNewSession(id, config.sessionTimeoutInSeconds)(fakeRequest, global), 10.seconds)
+          val value = Crypto.sign(token) + token
+          fakeRequest.withCookies(Cookie(cta.cookieName, value, None, cta.cookiePathOption, cta.cookieDomainOption, cta.cookieSecureOption, cta.cookieHttpOnlyOption))
+
+        case _ => throw new UnsupportedOperationException("withLoggedIn is currently " +
+          "only supported when using the CookieTokenAccessor")
+      }
     }
 
   }


### PR DESCRIPTION
Access the cookie params via the protected members of `CookieTokenAccessor`, rather than via the (deprecated) members of `AuthConfig`, which now throw an error.

I trust it's not this change which is causing the cache-related test failures!