### PR TITLE
support controller tests without application in context

### DIFF
--- a/module/src/main/scala/jp/t2v/lab/play2/auth/AsyncAuth.scala
+++ b/module/src/main/scala/jp/t2v/lab/play2/auth/AsyncAuth.scala
@@ -36,7 +36,7 @@ trait AsyncAuth {
   }
 
   private[auth] def extractToken(request: RequestHeader): Option[AuthenticityToken] = {
-    if (play.api.Play.isTest(play.api.Play.current)) {
+    if (play.api.Play.maybeApplication.forall(app => play.api.Play.isTest(app))) {
       request.headers.get("PLAY2_AUTH_TEST_TOKEN") orElse tokenAccessor.extract(request)
     } else {
       tokenAccessor.extract(request)

--- a/module/src/main/scala/jp/t2v/lab/play2/auth/AuthConfig.scala
+++ b/module/src/main/scala/jp/t2v/lab/play2/auth/AuthConfig.scala
@@ -50,7 +50,7 @@ trait AuthConfig {
 
   lazy val tokenAccessor: TokenAccessor = new CookieTokenAccessor(
     cookieName = "PLAY2AUTH_SESS_ID",
-    cookieSecureOption = play.api.Play.isProd(play.api.Play.current),
+    cookieSecureOption = play.api.Play.maybeApplication.exists(app => play.api.Play.isProd(app)),
     cookieHttpOnlyOption = true,
     cookieDomainOption = None,
     cookiePathOption = "/",


### PR DESCRIPTION
WithApplication tests are much slower (starting a new app for every controller test) this pull request remove the assumption there's a play application in context allowing faster tests