### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Play2.x module for Authentication and Authorization [![Build Status](https://secure.travis-ci.org/t2v/play2-auth.png)](http://travis-ci.org/t2v/play2-auth)
+Play2.x module for Authentication and Authorization [![Build Status](https://secure.travis-ci.org/t2v/play2-auth.png)](https://travis-ci.org/t2v/play2-auth)
 ===========================================================
 [![Gitter](https://badges.gitter.im/Join Chat.svg)](https://gitter.im/t2v/play2-auth?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
@@ -481,7 +481,7 @@ object Application extends Controller with TokenValidateElement with AuthElement
 
 ### Asynchronous Support
 
-There are asynchronous libraries ( for example: [ReactiveMongo](http://reactivemongo.org/), [ScalikeJDBC-Async](https://github.com/seratch/scalikejdbc-async), and so on ).
+There are asynchronous libraries ( for example: [ReactiveMongo](http://reactivemongo.org/), [ScalikeJDBC-Async](https://github.com/scalikejdbc/scalikejdbc-async), and so on ).
 
 You should use `Future[Result]` instead of `AsyncResult` from Play2.2. 
 
@@ -545,7 +545,7 @@ Running The Sample Application
 Attention -- Distributed Servers
 ---------------------------------------
 
-[Ehcache](http://ehcache.org), the default cache implementation used by Play2.x, does not work on distributed application servers.
+[Ehcache](http://www.ehcache.org/), the default cache implementation used by Play2.x, does not work on distributed application servers.
 
 If you have distributed servers, use the [Memcached Plugin](https://github.com/mumoshu/play2-memcached) or something similar.
 


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein

### GitHub Corrected URLs 
Was | Now 
--- | --- 
https://github.com/seratch/scalikejdbc-async | https://github.com/scalikejdbc/scalikejdbc-async 


### HTTPS Corrected URLs 
Was | Now 
--- | --- 
http://travis-ci.org/t2v/play2-auth | https://travis-ci.org/t2v/play2-auth 


### Other Corrected URLs 
Was | Now 
--- | --- 
http://ehcache.org | http://www.ehcache.org/ 
