### PR TITLE
Removed the use of play.api.Application and play.api.Cache singletons

### DIFF
--- a/module/src/main/scala/jp/t2v/lab/play2/auth/AsyncAuth.scala
+++ b/module/src/main/scala/jp/t2v/lab/play2/auth/AsyncAuth.scala
@@ -1,7 +1,9 @@
 package jp.t2v.lab.play2.auth
 
+import play.api.Mode
 import play.api.mvc._
-import scala.concurrent.{ExecutionContext, Future}
+
+import scala.concurrent.{ ExecutionContext, Future }
 
 trait AsyncAuth {
     self: AuthConfig with Controller =>
@@ -36,7 +38,7 @@ trait AsyncAuth {
   }
 
   private[auth] def extractToken(request: RequestHeader): Option[AuthenticityToken] = {
-    if (play.api.Play.maybeApplication.forall(app => play.api.Play.isTest(app))) {
+    if (environment.mode == Mode.Test) {
       request.headers.get("PLAY2_AUTH_TEST_TOKEN") orElse tokenAccessor.extract(request)
     } else {
       tokenAccessor.extract(request)

--- a/module/src/main/scala/jp/t2v/lab/play2/auth/AuthConfig.scala
+++ b/module/src/main/scala/jp/t2v/lab/play2/auth/AuthConfig.scala
@@ -1,8 +1,11 @@
 package jp.t2v.lab.play2.auth
 
+import play.api.{ Environment, Mode }
+import play.api.cache.CacheApi
 import play.api.mvc._
-import scala.reflect.{ClassTag, classTag}
-import scala.concurrent.{ExecutionContext, Future}
+
+import scala.reflect.{ ClassTag, classTag }
+import scala.concurrent.{ ExecutionContext, Future }
 
 trait AuthConfig {
 
@@ -11,6 +14,10 @@ trait AuthConfig {
   type User
 
   type Authority
+
+  val environment: Environment
+
+  val idContainer: AsyncIdContainer[Id]
 
   implicit def idTag: ClassTag[Id]
 
@@ -27,8 +34,6 @@ trait AuthConfig {
   def authorizationFailed(request: RequestHeader, user: User, authority: Option[Authority])(implicit context: ExecutionContext): Future[Result]
 
   def authorize(user: User, authority: Authority)(implicit context: ExecutionContext): Future[Boolean]
-
-  lazy val idContainer: AsyncIdContainer[Id] = AsyncIdContainer(new CacheIdContainer[Id])
 
   @deprecated("it will be deleted since 0.14.x. use CookieTokenAccessor constructor", since = "0.13.1")
   final lazy val cookieName: String = throw new AssertionError("use tokenAccessor setting instead.")
@@ -50,7 +55,7 @@ trait AuthConfig {
 
   lazy val tokenAccessor: TokenAccessor = new CookieTokenAccessor(
     cookieName = "PLAY2AUTH_SESS_ID",
-    cookieSecureOption = play.api.Play.maybeApplication.exists(app => play.api.Play.isProd(app)),
+    cookieSecureOption = environment.mode == Mode.Prod,
     cookieHttpOnlyOption = true,
     cookieDomainOption = None,
     cookiePathOption = "/",

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -118,6 +118,7 @@ object ApplicationBuild extends Build {
       name                := appName + "-social",
       libraryDependencies += "com.typesafe.play" %% "play"       % playVersion % "provided",
       libraryDependencies += "com.typesafe.play" %% "play-ws"    % playVersion % "provided",
+      libraryDependencies += "com.typesafe.play" %% "play-cache" % playVersion % "provided",
       publishMavenStyle       := appPublishMavenStyle,
       publishArtifact in Test := appPublishArtifactInTest,
       pomIncludeRepository    := appPomIncludeRepository,

--- a/sample/app/controllers/basic/Messages.scala
+++ b/sample/app/controllers/basic/Messages.scala
@@ -1,13 +1,16 @@
 package controllers.basic
 
+import javax.inject.Inject
+
 import controllers.stack.Pjax
 import jp.t2v.lab.play2.auth.AuthElement
 import play.api.mvc.Controller
 import views.html
 import jp.t2v.lab.play2.auth.sample.Role._
+import play.api.Environment
 import play.twirl.api.Html
 
-trait Messages extends Controller with AuthElement with AuthConfigImpl {
+class Messages @Inject() (val environment: Environment) extends Controller with AuthElement with AuthConfigImpl {
 
   def main = StackAction(AuthorityKey -> NormalUser) { implicit request =>
     val title = "message main"
@@ -32,4 +35,3 @@ trait Messages extends Controller with AuthElement with AuthConfigImpl {
   protected implicit def template(implicit user: User): String => Html => Html = html.basic.fullTemplate(user)
 
 }
-object Messages extends Messages

--- a/sample/app/controllers/builder/Messages.scala
+++ b/sample/app/controllers/builder/Messages.scala
@@ -1,11 +1,14 @@
 package controllers.builder
 
+import javax.inject.Inject
+
 import jp.t2v.lab.play2.auth.AuthActionBuilders
 import jp.t2v.lab.play2.auth.sample.Account
 import jp.t2v.lab.play2.auth.sample.Role._
+import play.api.Environment
 import play.api.mvc._
 import play.twirl.api.Html
-import scalikejdbc.{DB, DBSession}
+import scalikejdbc.{ DB, DBSession }
 import views.html
 
 import scala.concurrent.Future
@@ -21,7 +24,7 @@ object TransactionalAction extends ActionBuilder[TransactionalRequest] {
   }
 }
 
-trait Messages extends Controller with AuthActionBuilders with AuthConfigImpl {
+class Messages @Inject() (val environment: Environment) extends Controller with AuthActionBuilders with AuthConfigImpl {
 
   type AuthTxRequest[+A] = GenericAuthRequest[A, TransactionalRequest]
   final def AuthorizationTxAction(authority: Authority): ActionBuilder[AuthTxRequest] = composeAuthorizationAction(TransactionalAction)(authority)
@@ -58,4 +61,3 @@ trait Messages extends Controller with AuthActionBuilders with AuthConfigImpl {
   }
 
 }
-object Messages extends Messages

--- a/sample/app/controllers/builder/Sessions.scala
+++ b/sample/app/controllers/builder/Sessions.scala
@@ -1,16 +1,19 @@
 package controllers.builder
 
+import javax.inject.Inject
+
 import jp.t2v.lab.play2.auth.LoginLogout
 import jp.t2v.lab.play2.auth.sample.Account
+import play.api.Environment
 import play.api.data.Form
 import play.api.data.Forms._
-import play.api.mvc.{Action, Controller}
+import play.api.mvc.{ Action, Controller }
 import views.html
 
 import scala.concurrent.Future
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 
-object Sessions  extends Controller with LoginLogout with AuthConfigImpl {
+class Sessions @Inject() (val environment: Environment) extends Controller with LoginLogout with AuthConfigImpl {
 
   val loginForm = Form {
     mapping("email" -> email, "password" -> text)(Account.authenticate)(_.map(u => (u.email, "")))

--- a/sample/app/controllers/csrf/PreventingCsrfSample.scala
+++ b/sample/app/controllers/csrf/PreventingCsrfSample.scala
@@ -1,13 +1,16 @@
 package controllers.csrf
 
+import javax.inject.Inject
+
 import controllers.stack.TokenValidateElement
 import jp.t2v.lab.play2.auth.AuthElement
 import jp.t2v.lab.play2.auth.sample.Role._
+import play.api.Environment
 import play.api.data.Form
 import play.api.data.Forms._
 import play.api.mvc.Controller
 
-trait PreventingCsrfSample extends Controller with TokenValidateElement with AuthElement with AuthConfigImpl {
+class PreventingCsrfSample @Inject() (val environment: Environment) extends Controller with TokenValidateElement with AuthElement with AuthConfigImpl {
 
   def formWithToken = StackAction(AuthorityKey -> NormalUser, IgnoreTokenValidation -> true) { implicit req =>
     Ok(views.html.csrf.formWithToken())
@@ -27,4 +30,3 @@ trait PreventingCsrfSample extends Controller with TokenValidateElement with Aut
   }
 
 }
-object PreventingCsrfSample extends PreventingCsrfSample

--- a/sample/app/controllers/csrf/Sessions.scala
+++ b/sample/app/controllers/csrf/Sessions.scala
@@ -1,16 +1,19 @@
 package controllers.csrf
 
+import javax.inject.Inject
+
 import jp.t2v.lab.play2.auth.LoginLogout
 import jp.t2v.lab.play2.auth.sample.Account
+import play.api.Environment
 import play.api.data.Form
 import play.api.data.Forms._
-import play.api.mvc.{Action, Controller}
+import play.api.mvc.{ Action, Controller }
 import views.html
 
 import scala.concurrent.Future
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 
-object Sessions  extends Controller with LoginLogout with AuthConfigImpl {
+class Sessions @Inject() (val environment: Environment) extends Controller with LoginLogout with AuthConfigImpl {
 
   val loginForm = Form {
     mapping("email" -> email, "password" -> text)(Account.authenticate)(_.map(u => (u.email, "")))

--- a/sample/app/controllers/ephemeral/Messages.scala
+++ b/sample/app/controllers/ephemeral/Messages.scala
@@ -1,12 +1,15 @@
 package controllers.ephemeral
 
+import javax.inject.Inject
+
 import controllers.stack.Pjax
 import jp.t2v.lab.play2.auth.AuthElement
 import play.api.mvc.Controller
 import views.html
 import jp.t2v.lab.play2.auth.sample.Role._
+import play.api.Environment
 
-trait Messages extends Controller with Pjax with AuthElement with AuthConfigImpl {
+class Messages @Inject() (val environment: Environment) extends Controller with Pjax with AuthElement with AuthConfigImpl {
 
   def main = StackAction(AuthorityKey -> NormalUser) { implicit request =>
     val title = "message main"
@@ -31,4 +34,3 @@ trait Messages extends Controller with Pjax with AuthElement with AuthConfigImpl
   protected val fullTemplate: User => Template = html.ephemeral.fullTemplate.apply
 
 }
-object Messages extends Messages

--- a/sample/app/controllers/ephemeral/Sessions.scala
+++ b/sample/app/controllers/ephemeral/Sessions.scala
@@ -1,16 +1,19 @@
 package controllers.ephemeral
 
+import javax.inject.Inject
+
 import jp.t2v.lab.play2.auth.LoginLogout
 import jp.t2v.lab.play2.auth.sample.Account
+import play.api.Environment
 import play.api.data.Form
 import play.api.data.Forms._
-import play.api.mvc.{Action, Controller}
+import play.api.mvc.{ Action, Controller }
 import views.html
 
 import scala.concurrent.Future
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 
-object Sessions  extends Controller with LoginLogout with AuthConfigImpl {
+class Sessions @Inject() (val environment: Environment) extends Controller with LoginLogout with AuthConfigImpl {
 
   val loginForm = Form {
     mapping("email" -> email, "password" -> text)(Account.authenticate)(_.map(u => (u.email, "")))

--- a/sample/app/controllers/rememberme/Messages.scala
+++ b/sample/app/controllers/rememberme/Messages.scala
@@ -1,12 +1,15 @@
 package controllers.rememberme
 
+import javax.inject.Inject
+
 import controllers.stack.Pjax
 import jp.t2v.lab.play2.auth.AuthElement
 import play.api.mvc.Controller
 import views.html
 import jp.t2v.lab.play2.auth.sample.Role._
+import play.api.Environment
 
-trait Messages extends Controller with Pjax with AuthElement with AuthConfigImpl {
+class Messages @Inject() (val environment: Environment) extends Controller with Pjax with AuthElement with AuthConfigImpl {
 
   def main = StackAction(AuthorityKey -> NormalUser) { implicit request =>
     val title = "message main"
@@ -31,4 +34,3 @@ trait Messages extends Controller with Pjax with AuthElement with AuthConfigImpl
   protected val fullTemplate: User => Template = html.rememberme.fullTemplate.apply
 
 }
-object Messages extends Messages

--- a/sample/app/controllers/rememberme/Sessions.scala
+++ b/sample/app/controllers/rememberme/Sessions.scala
@@ -1,16 +1,19 @@
 package controllers.rememberme
 
+import javax.inject.Inject
+
 import jp.t2v.lab.play2.auth.LoginLogout
 import jp.t2v.lab.play2.auth.sample.Account
+import play.api.Environment
 import play.api.data.Form
 import play.api.data.Forms._
-import play.api.mvc.{Action, Controller}
+import play.api.mvc.{ Action, Controller }
 import views.html
 
 import scala.concurrent.Future
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 
-object Sessions extends Controller with LoginLogout with AuthConfigImpl {
+class Sessions @Inject() (val environment: Environment) extends Controller with LoginLogout with AuthConfigImpl {
 
   val loginForm = Form {
     mapping("email" -> email, "password" -> text)(Account.authenticate)(_.map(u => (u.email, "")))

--- a/sample/app/controllers/standard/Messages.scala
+++ b/sample/app/controllers/standard/Messages.scala
@@ -1,12 +1,15 @@
 package controllers.standard
 
+import javax.inject.Inject
+
 import controllers.stack.Pjax
 import jp.t2v.lab.play2.auth.AuthElement
 import play.api.mvc.Controller
 import views.html
 import jp.t2v.lab.play2.auth.sample.Role._
+import play.api.Environment
 
-trait Messages extends Controller with Pjax with AuthElement with AuthConfigImpl {
+class Messages @Inject() (val environment: Environment) extends Controller with Pjax with AuthElement with AuthConfigImpl {
 
   def main = StackAction(AuthorityKey -> NormalUser) { implicit request =>
     val title = "message main"
@@ -31,4 +34,3 @@ trait Messages extends Controller with Pjax with AuthElement with AuthConfigImpl
   protected val fullTemplate: User => Template = html.standard.fullTemplate.apply
 
 }
-object Messages extends Messages

--- a/sample/app/controllers/standard/Sessions.scala
+++ b/sample/app/controllers/standard/Sessions.scala
@@ -1,16 +1,19 @@
 package controllers.standard
 
+import javax.inject.Inject
+
 import jp.t2v.lab.play2.auth.LoginLogout
 import jp.t2v.lab.play2.auth.sample.Account
+import play.api.Environment
 import play.api.data.Form
 import play.api.data.Forms._
-import play.api.mvc.{Action, Controller}
+import play.api.mvc.{ Action, Controller }
 import views.html
 
 import scala.concurrent.Future
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 
-object Sessions extends Controller with LoginLogout with AuthConfigImpl {
+class Sessions @Inject() (val environment: Environment) extends Controller with LoginLogout with AuthConfigImpl {
 
   val loginForm = Form {
     mapping("email" -> email, "password" -> text)(Account.authenticate)(_.map(u => (u.email, "")))

--- a/sample/app/controllers/stateless/Messages.scala
+++ b/sample/app/controllers/stateless/Messages.scala
@@ -1,12 +1,15 @@
 package controllers.stateless
 
+import javax.inject.Inject
+
 import controllers.stack.Pjax
 import jp.t2v.lab.play2.auth.AuthElement
 import play.api.mvc.Controller
 import views.html
 import jp.t2v.lab.play2.auth.sample.Role._
+import play.api.Environment
 
-trait Messages extends Controller with Pjax with AuthElement with AuthConfigImpl {
+class Messages @Inject() (val environment: Environment) extends Controller with Pjax with AuthElement with AuthConfigImpl {
 
   def main = StackAction(AuthorityKey -> NormalUser) { implicit request =>
     val title = "message main"
@@ -31,4 +34,3 @@ trait Messages extends Controller with Pjax with AuthElement with AuthConfigImpl
   protected val fullTemplate: User => Template = html.stateless.fullTemplate.apply
 
 }
-object Messages extends Messages

--- a/sample/app/controllers/stateless/Sessions.scala
+++ b/sample/app/controllers/stateless/Sessions.scala
@@ -1,16 +1,19 @@
 package controllers.stateless
 
+import javax.inject.Inject
+
 import jp.t2v.lab.play2.auth.LoginLogout
 import jp.t2v.lab.play2.auth.sample.Account
+import play.api.Environment
 import play.api.data.Form
 import play.api.data.Forms._
-import play.api.mvc.{Action, Controller}
+import play.api.mvc.{ Action, Controller }
 import views.html
 
 import scala.concurrent.Future
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 
-object Sessions extends Controller with LoginLogout with AuthConfigImpl {
+class Sessions @Inject() (val environment: Environment) extends Controller with LoginLogout with AuthConfigImpl {
 
   val loginForm = Form {
     mapping("email" -> email, "password" -> text)(Account.authenticate)(_.map(u => (u.email, "")))

--- a/sample/conf/routes
+++ b/sample/conf/routes
@@ -3,74 +3,74 @@
 # ~~~~
 
 # Standard
-GET     /                                     controllers.standard.Sessions.login
-POST    /standard/login                       controllers.standard.Sessions.authenticate
-GET     /standard/logout                      controllers.standard.Sessions.logout
+GET     /                                     @controllers.standard.Sessions.login
+POST    /standard/login                       @controllers.standard.Sessions.authenticate
+GET     /standard/logout                      @controllers.standard.Sessions.logout
 
-GET     /standard/messages/main               controllers.standard.Messages.main
-GET     /standard/messages/list               controllers.standard.Messages.list
-GET     /standard/messages/detail/:id         controllers.standard.Messages.detail(id: Int)
-GET     /standard/messages/write              controllers.standard.Messages.write
+GET     /standard/messages/main               @controllers.standard.Messages.main
+GET     /standard/messages/list               @controllers.standard.Messages.list
+GET     /standard/messages/detail/:id         @controllers.standard.Messages.detail(id: Int)
+GET     /standard/messages/write              @controllers.standard.Messages.write
 
 # Builder
-GET     /builder/                          controllers.builder.Sessions.login
-POST    /builder/login                     controllers.builder.Sessions.authenticate
-GET     /builder/logout                    controllers.builder.Sessions.logout
+GET     /builder/                          @controllers.builder.Sessions.login
+POST    /builder/login                     @controllers.builder.Sessions.authenticate
+GET     /builder/logout                    @controllers.builder.Sessions.logout
 
-GET     /builder/messages/main             controllers.builder.Messages.main
-GET     /builder/messages/list             controllers.builder.Messages.list
-GET     /builder/messages/detail/:id       controllers.builder.Messages.detail(id: Int)
-GET     /builder/messages/write            controllers.builder.Messages.write
+GET     /builder/messages/main             @controllers.builder.Messages.main
+GET     /builder/messages/list             @controllers.builder.Messages.list
+GET     /builder/messages/detail/:id       @controllers.builder.Messages.detail(id: Int)
+GET     /builder/messages/write            @controllers.builder.Messages.write
 
 # Csrf
-GET     /csrf/                             controllers.csrf.Sessions.login
-POST    /csrf/login                        controllers.csrf.Sessions.authenticate
-GET     /csrf/logout                       controllers.csrf.Sessions.logout
+GET     /csrf/                             @controllers.csrf.Sessions.login
+POST    /csrf/login                        @controllers.csrf.Sessions.authenticate
+GET     /csrf/logout                       @controllers.csrf.Sessions.logout
 
-GET     /csrf/with_token                   controllers.csrf.PreventingCsrfSample.formWithToken
-GET     /csrf/without_token                controllers.csrf.PreventingCsrfSample.formWithoutToken
-POST    /csrf/                             controllers.csrf.PreventingCsrfSample.submitTarget
+GET     /csrf/with_token                   @controllers.csrf.PreventingCsrfSample.formWithToken
+GET     /csrf/without_token                @controllers.csrf.PreventingCsrfSample.formWithoutToken
+POST    /csrf/                             @controllers.csrf.PreventingCsrfSample.submitTarget
 
 
 # Ephemeral
-GET     /ephemeral/                          controllers.ephemeral.Sessions.login
-POST    /ephemeral/login                     controllers.ephemeral.Sessions.authenticate
-GET     /ephemeral/logout                    controllers.ephemeral.Sessions.logout
+GET     /ephemeral/                          @controllers.ephemeral.Sessions.login
+POST    /ephemeral/login                     @controllers.ephemeral.Sessions.authenticate
+GET     /ephemeral/logout                    @controllers.ephemeral.Sessions.logout
 
-GET     /ephemeral/messages/main             controllers.ephemeral.Messages.main
-GET     /ephemeral/messages/list             controllers.ephemeral.Messages.list
-GET     /ephemeral/messages/detail/:id       controllers.ephemeral.Messages.detail(id: Int)
-GET     /ephemeral/messages/write            controllers.ephemeral.Messages.write
+GET     /ephemeral/messages/main             @controllers.ephemeral.Messages.main
+GET     /ephemeral/messages/list             @controllers.ephemeral.Messages.list
+GET     /ephemeral/messages/detail/:id       @controllers.ephemeral.Messages.detail(id: Int)
+GET     /ephemeral/messages/write            @controllers.ephemeral.Messages.write
 
 # Stateless
-GET     /stateless/                          controllers.stateless.Sessions.login
-POST    /stateless/login                     controllers.stateless.Sessions.authenticate
-GET     /stateless/logout                    controllers.stateless.Sessions.logout
+GET     /stateless/                          @controllers.stateless.Sessions.login
+POST    /stateless/login                     @controllers.stateless.Sessions.authenticate
+GET     /stateless/logout                    @controllers.stateless.Sessions.logout
 
-GET     /stateless/messages/main             controllers.stateless.Messages.main
-GET     /stateless/messages/list             controllers.stateless.Messages.list
-GET     /stateless/messages/detail/:id       controllers.stateless.Messages.detail(id: Int)
-GET     /stateless/messages/write            controllers.stateless.Messages.write
+GET     /stateless/messages/main             @controllers.stateless.Messages.main
+GET     /stateless/messages/list             @controllers.stateless.Messages.list
+GET     /stateless/messages/detail/:id       @controllers.stateless.Messages.detail(id: Int)
+GET     /stateless/messages/write            @controllers.stateless.Messages.write
 
 
 # HTTP Basic Auth
-GET     /basic/                            controllers.Default.redirect(to = "/basic/messages/main")
-GET     /basic/messages/main               controllers.basic.Messages.main
-GET     /basic/messages/list               controllers.basic.Messages.list
-GET     /basic/messages/detail/:id         controllers.basic.Messages.detail(id: Int)
-GET     /basic/messages/write              controllers.basic.Messages.write
+GET     /basic/                            @controllers.Default.redirect(to = "/basic/messages/main")
+GET     /basic/messages/main               @controllers.basic.Messages.main
+GET     /basic/messages/list               @controllers.basic.Messages.list
+GET     /basic/messages/detail/:id         @controllers.basic.Messages.detail(id: Int)
+GET     /basic/messages/write              @controllers.basic.Messages.write
 
 
 # Remember Me
-GET     /rememberme/                            controllers.rememberme.Sessions.login
-POST    /rememberme/login                       controllers.rememberme.Sessions.authenticate
-GET     /rememberme/logout                      controllers.rememberme.Sessions.logout
+GET     /rememberme/                            @controllers.rememberme.Sessions.login
+POST    /rememberme/login                       @controllers.rememberme.Sessions.authenticate
+GET     /rememberme/logout                      @controllers.rememberme.Sessions.logout
 
-GET     /rememberme/messages/main               controllers.rememberme.Messages.main
-GET     /rememberme/messages/list               controllers.rememberme.Messages.list
-GET     /rememberme/messages/detail/:id         controllers.rememberme.Messages.detail(id: Int)
-GET     /rememberme/messages/write              controllers.rememberme.Messages.write
+GET     /rememberme/messages/main               @controllers.rememberme.Messages.main
+GET     /rememberme/messages/list               @controllers.rememberme.Messages.list
+GET     /rememberme/messages/detail/:id         @controllers.rememberme.Messages.detail(id: Int)
+GET     /rememberme/messages/write              @controllers.rememberme.Messages.write
 
 
 # Map static resources from the /public folder to the /assets URL path
-GET     /assets/*file               controllers.Assets.at(path="/public", file)
+GET     /assets/*file               @controllers.Assets.at(path="/public", file)

--- a/sample/test/ApplicationSpec.scala
+++ b/sample/test/ApplicationSpec.scala
@@ -1,20 +1,23 @@
 package test
 
 import org.specs2.mutable._
-
 import play.api.test._
 import play.api.test.Helpers._
-import controllers.standard.{AuthConfigImpl, Messages}
+import controllers.standard.{ AuthConfigImpl, Messages }
 import jp.t2v.lab.play2.auth.test.Helpers._
 import java.io.File
 
+import play.api.Environment
+
 class ApplicationSpec extends Specification {
 
-  object config extends AuthConfigImpl
+  object config extends AuthConfigImpl {
+    override val environment: Environment = Environment.simple()
+  }
 
   "Messages" should {
     "return list when user is authorized" in new WithApplication(FakeApplication(additionalConfiguration = inMemoryDatabase(name = "default", options = Map("DB_CLOSE_DELAY" -> "-1")))) {
-      val res = Messages.list(FakeRequest().withLoggedIn(config)(1))
+      val res = new Messages(Environment.simple()).list(FakeRequest().withLoggedIn(config)(1))
       contentType(res) must beSome("text/html")
     }
   }

--- a/social-sample/conf/routes
+++ b/social-sample/conf/routes
@@ -1,17 +1,17 @@
-GET        /                          controllers.Application.index
-GET        /logout                    controllers.Application.logout
+GET        /                          @controllers.Application.index
+GET        /logout                    @controllers.Application.logout
 
-GET        /login/twitter             controllers.TwitterAuthController.login
-GET        /link/twitter              controllers.TwitterAuthController.link
-GET        /authorize/twitter         controllers.TwitterAuthController.authorize
+GET        /login/twitter             @controllers.TwitterAuthController.login
+GET        /link/twitter              @controllers.TwitterAuthController.link
+GET        /authorize/twitter         @controllers.TwitterAuthController.authorize
 
-GET        /login/github              controllers.GitHubAuthController.login(scope: String)
-GET        /link/github               controllers.GitHubAuthController.link(scope: String)
-GET        /authorize/github          controllers.GitHubAuthController.authorize
+GET        /login/github              @controllers.GitHubAuthController.login(scope: String)
+GET        /link/github               @controllers.GitHubAuthController.link(scope: String)
+GET        /authorize/github          @controllers.GitHubAuthController.authorize
 
-GET        /login/facebook            controllers.FacebookAuthController.login(scope: String)
-GET        /link/facebook             controllers.FacebookAuthController.link(scope: String)
-GET        /authorize/facebook        controllers.FacebookAuthController.authorize
+GET        /login/facebook            @controllers.FacebookAuthController.login(scope: String)
+GET        /link/facebook             @controllers.FacebookAuthController.link(scope: String)
+GET        /authorize/facebook        @controllers.FacebookAuthController.authorize
 
-GET        /link/slack                controllers.SlackAuthController.link(scope: String)
-GET        /authorize/slack           controllers.SlackAuthController.authorize
+GET        /link/slack                @controllers.SlackAuthController.link(scope: String)
+GET        /authorize/slack           @controllers.SlackAuthController.authorize


### PR DESCRIPTION
Since Play 2.4, the use of `play.api.Application` and `play.api.Cache` is deprecated and not recommended.
`play.api.Cache` singleton should be replaced with `CacheApi` and `play.api.Application` with `Configuration/Environment`.

To minimize the change, I think It's reasonable to add fields of `CacheApi/Environment` to `AuthConfig` trait. But it is not always the case for `CacheApi`. `CacheApi` is used only when `CacheIdContainer` is used as `IdContainer`. It is already discussed in https://github.com/t2v/play2-auth/issues/155. So I added `idContainer` field instead.

As for `play.api.Environment` which is the substitute of `play.api.Application`, I can say the same thing as `CacheApi`. It is used for only when `CookieTokenAccessor`.
However, should I added a tokenAccessor field to AuthConfig instead of Environment? It's a little difficult but I don't think it's necessary because `Environment` is also in `AsyncAuth` and much more commonly used than `CacheApi` in Play app.
