### PR TITLE
Remove Play's Crypto & implement Signer(For future Play2.6 support )

### DIFF
--- a/module/src/main/scala/jp/t2v/lab/play2/auth/CookieTokenAccessor.scala
+++ b/module/src/main/scala/jp/t2v/lab/play2/auth/CookieTokenAccessor.scala
@@ -17,7 +17,7 @@ class CookieTokenAccessor(
   }
 
   def extract(request: RequestHeader): Option[AuthenticityToken] = {
-    request.cookies.get(cookieName).flatMap(c => verifyHmac(c.value))
+    request.cookies.get(cookieName).flatMap(c => verifySignedToken(c.value))
   }
 
   def delete(result: Result)(implicit request: RequestHeader): Result = {

--- a/module/src/main/scala/jp/t2v/lab/play2/auth/LoginLogout.scala
+++ b/module/src/main/scala/jp/t2v/lab/play2/auth/LoginLogout.scala
@@ -1,9 +1,8 @@
 package jp.t2v.lab.play2.auth
 
 import play.api.mvc._
-import play.api.mvc.Cookie
-import play.api.libs.Crypto
-import scala.concurrent.{Future, ExecutionContext}
+
+import scala.concurrent.{ExecutionContext, Future}
 
 trait Login {
   self: Controller with AuthConfig =>

--- a/module/src/main/scala/jp/t2v/lab/play2/auth/TokenAccessor.scala
+++ b/module/src/main/scala/jp/t2v/lab/play2/auth/TokenAccessor.scala
@@ -1,7 +1,7 @@
 package jp.t2v.lab.play2.auth
 
-import play.api.mvc.{Result, RequestHeader}
-import play.api.libs.Crypto
+import jp.t2v.lab.play2.auth.crypto.Signer
+import play.api.mvc.{RequestHeader, Result}
 
 trait TokenAccessor {
 
@@ -11,26 +11,11 @@ trait TokenAccessor {
 
   def delete(result: Result)(implicit request: RequestHeader): Result
 
-  protected def verifyHmac(token: SignedToken): Option[AuthenticityToken] = {
-    val (hmac, value) = token.splitAt(40)
-    if (safeEquals(Crypto.sign(value), hmac)) Some(value) else None
-  }
+  protected def sign(token: AuthenticityToken): SignedToken = Signer.sign(token) + token
 
-  protected def sign(token: AuthenticityToken): SignedToken = Crypto.sign(token) + token
-
-  // Do not change this unless you understand the security issues behind timing attacks.
-  // This method intentionally runs in constant time if the two strings have the same length.
-  // If it didn't, it would be vulnerable to a timing attack.
-  protected def safeEquals(a: String, b: String) = {
-    if (a.length != b.length) {
-      false
-    } else {
-      var equal = 0
-      for (i <- Array.range(0, a.length)) {
-        equal |= a(i) ^ b(i)
-      }
-      equal == 0
-    }
+  protected def verifySignedToken(token: SignedToken): Option[AuthenticityToken] = {
+    val (signature, value) = token.splitAt(40)
+    if (Signer.verify(value, signature)) Some(value) else None
   }
 
 }

--- a/module/src/main/scala/jp/t2v/lab/play2/auth/crypto/Signer.scala
+++ b/module/src/main/scala/jp/t2v/lab/play2/auth/crypto/Signer.scala
@@ -1,0 +1,41 @@
+package jp.t2v.lab.play2.auth.crypto
+
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+
+import com.typesafe.config.ConfigFactory
+import jp.t2v.lab.play2.auth._
+import org.apache.commons.codec.binary.Hex
+
+trait Signer {
+  val secret: String
+
+  private lazy val mac: Mac = {
+    val mac = Mac.getInstance("HmacSHA1")
+    mac.init(new SecretKeySpec(secret.getBytes, "HmacSHA1"))
+    mac
+  }
+
+  def sign(token: AuthenticityToken): AuthenticityTokenSignature = Hex.encodeHexString(mac.doFinal(token.getBytes("utf-8")))
+
+  def verify(token: AuthenticityToken, signature: AuthenticityTokenSignature): Boolean = safeEquals(sign(token), signature)
+
+  // Do not change this unless you understand the security issues behind timing attacks.
+  // This method intentionally runs in constant time if the two strings have the same length.
+  // If it didn't, it would be vulnerable to a timing attack.
+  protected def safeEquals(a: String, b: String): Boolean = {
+    if (a.length != b.length) {
+      false
+    } else {
+      var equal = 0
+      for (i <- Array.range(0, a.length)) {
+        equal |= a(i) ^ b(i)
+      }
+      equal == 0
+    }
+  }
+}
+
+object Signer extends Signer {
+  override val secret: String = ConfigFactory.load().getString("play.crypto.secret")
+}

--- a/module/src/main/scala/jp/t2v/lab/play2/auth/package.scala
+++ b/module/src/main/scala/jp/t2v/lab/play2/auth/package.scala
@@ -5,6 +5,7 @@ import play.api.mvc.Result
 package object auth {
 
   type AuthenticityToken = String
+  type AuthenticityTokenSignature = String
   type SignedToken = String
 
   type ResultUpdater = Result => Result

--- a/module/src/test/scala/jp/t2v/lab/play2/auth/crypto/SignerSpec.scala
+++ b/module/src/test/scala/jp/t2v/lab/play2/auth/crypto/SignerSpec.scala
@@ -1,0 +1,36 @@
+package jp.t2v.lab.play2.auth.crypto
+
+import org.scalatest.{FunSpec, MustMatchers}
+
+class SignerSpec extends FunSpec with MustMatchers {
+  val signer = new Signer {
+    override val secret = "play2.auth.secret"
+  }
+
+  describe("Signer"){
+    describe("sign") {
+      it("should return signature of given authToken using HMAC-SHA1") {
+        val signature = signer.sign("authToken")
+
+        signature mustBe "c1e3dd7d8f5ffe920006445fe46c216e12f9b6a7"
+      }
+    }
+
+    describe("verify") {
+      it("should return true when signature of given authToken corresponds given signature") {
+        val authToken = "authToken"
+        val signature = signer.sign("authToken")
+
+        signer.verify(authToken, signature) mustBe true
+      }
+
+      it("should return false when signature of given authToken does not correspond given signature") {
+        val authToken = "authToken1"
+        val signature = signer.sign("authToken2")
+
+        signer.verify(authToken, signature) mustBe false
+      }
+    }
+  }
+
+}

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -59,6 +59,7 @@ object ApplicationBuild extends Build {
       libraryDependencies += "com.typesafe.play"  %%   "play"                   % playVersion        % "provided",
       libraryDependencies += "com.typesafe.play"  %%   "play-cache"             % playVersion        % "provided",
       libraryDependencies += "jp.t2v"             %%   "stackable-controller"   % "0.5.1",
+      libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.4" % "test",
       name                    := appName,
       publishMavenStyle       := appPublishMavenStyle,
       publishArtifact in Test := appPublishArtifactInTest,

--- a/test/src/main/scala/jp/t2v/lab/play2/auth/test/Helpers.scala
+++ b/test/src/main/scala/jp/t2v/lab/play2/auth/test/Helpers.scala
@@ -1,12 +1,11 @@
 package jp.t2v.lab.play2.auth.test
 
-import play.api.test._
-import play.api.mvc.Cookie
 import jp.t2v.lab.play2.auth.AuthConfig
-import play.api.libs.Crypto
+import play.api.test._
+
 import scala.concurrent.Await
-import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration._
 
 trait Helpers {
 


### PR DESCRIPTION
### Purpose of this PR
play.api.libs.Crypto is deprecated when Play2.5 released, then, removed when when Play2.6 released.
In order to use play2-auth with Play2.6, CryptoMigration is unavoidable.
This PR replaces play.api.libs.Crypto with Handmaid Signer(imitation of play.api.libs.Crypto).

### Detail of Implemented Signer
- Uses HMAC-SHA1 for signing (As Play2.4&2.5's Crypto do)
- Gets secret from `play.crypto.secret`in `application.conf` (As Play2.4&2.5's Crypto do)
	- this is violating `Key Separation Principle`.This should be fixed when play2-auth support Play2.6.
- Does not support DI

### Reference link
https://www.playframework.com/documentation/2.5.x/Migration25
https://www.playframework.com/documentation/2.6.x/Migration26
https://www.playframework.com/documentation/2.6.x/CryptoMigration25
